### PR TITLE
fix: resolve submodule sync race condition in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,9 @@ echo "✅ .gitmodules updated, submodules initialized, and all are on 'main'."
 
 echo "🔁 Syncing all submodules to 'main' branch..."
 
+# Ensure submodules are synced with the new .gitmodules before foreach
+git submodule sync
+
 # Loop over each initialized submodule
 git submodule foreach '
   echo "🛠 Switching to main in $name"


### PR DESCRIPTION
## Summary
- Fixes the `fatal: No url found for submodule path 'az-decompile' in .gitmodules` error
- Adds `git submodule sync` before `git submodule foreach` to prevent race condition
- Ensures git's internal submodule registry matches the regenerated .gitmodules file

## Root Cause
The error occurred due to a timing issue in the installation process:
1. Git initialized submodules from the original .gitmodules file
2. Script regenerated .gitmodules, temporarily removing/reordering entries  
3. `git submodule foreach` referenced stale submodule configuration

## Solution
Added `git submodule sync` at line 98 to synchronize git's internal submodule registry with the newly generated .gitmodules file before executing submodule operations.

## Test Plan
- [x] Verify the fix resolves the submodule sync error
- [ ] Test installation script in clean environment
- [ ] Confirm all 27 submodules initialize correctly

🤖 Generated with [Claude Code](https://claude.ai/code)