### PR TITLE
fix(workflow): add GH_TOKEN to sync-submodules workflow

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -21,6 +21,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run install.sh to sync submodules
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x ./install.sh
           ./install.sh


### PR DESCRIPTION
## Summary
- Fixed failing sync-submodules workflow by adding missing GH_TOKEN environment variable
- Resolves "fatal: No url found for submodule path" errors
- Enables proper GitHub CLI authentication in install.sh script

## Root Cause Analysis
The sync-submodules workflow was failing consistently because:

1. **Missing GitHub Token**: The install.sh script uses `gh` CLI but workflow didn't provide GH_TOKEN
2. **Fallback Failure**: When `gh` auth failed, script fell back to directory scanning 
3. **Empty .gitmodules**: Fallback produced empty .gitmodules file causing git submodule errors

## Changes
- Added `GH_TOKEN: ${{ github.token }}` to the "Run install.sh to sync submodules" step
- This enables proper GitHub CLI authentication and repository listing

## Test Plan
- [ ] Verify workflow runs successfully after merge
- [ ] Check that .gitmodules file is properly generated 
- [ ] Confirm submodules are correctly synced

🤖 Generated with [Claude Code](https://claude.ai/code)